### PR TITLE
Update bridge converter active logic

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -47,6 +47,7 @@ module.exports = Object.freeze({
     FLAG_LAUNCH_COMPLETE : 0x100,        // set if all currency information is verifiable on this chain
     FLAG_CONTRACT_UPGRADE: 512,
     FLAG_FRACTIONAL : 1,
+    FLAG_IMPORT_TO_SOURCE: 512,
     DEST_FULLID : 5,
     DEST_REGISTERCURRENCY : 6,
     UINT160_LENGTH: 20,

--- a/constants.js
+++ b/constants.js
@@ -24,6 +24,10 @@ module.exports = Object.freeze({
                             VRSCTEST: "iSojYsotVzXz4wh2eJriASGo6UidJDDhL2", 
                             VRSC: "i3f7tSctFkiPpiedY8QR5Tep9p4qDVebDx"
                         },
+    VETHIDHEX:          {
+                            VRSCTEST:"0x67460C2f56774eD27EeB8685f29f6CEC0B090B00",
+                            VRSC: "0x454cb83913d688795e237837d30258d11ea7c752"
+                        },
     VETHIDHEXREVERSED:  {
                             VRSCTEST:"000b090bec6c9ff28586eb7ed24e77562f0c4667",
                             VRSC: "52c7a71ed15802d33778235e7988d61339b84c45"

--- a/ethInteractor.js
+++ b/ethInteractor.js
@@ -811,8 +811,11 @@ exports.getExports = async(input) => {
 
             let outputSet = {};
 
-            bridgeConverterActive = exportSet.transfers[0].destcurrencyid.toLowerCase() === constants.BRIDGECURRENCYHEX[InteractorConfig.ticker].toLowerCase()
-                                        || exportSet.transfers[0].feecurrencyid.toLowerCase() === constants.VETHIDHEX[InteractorConfig.ticker].toLowerCase();
+            const importCurrency = (parseInt(exportSet.transfers[0].flags) & constants.FLAG_IMPORT_TO_SOURCE) > 0 ? 
+                                        exportSet.transfers[0].currencyvalue.currency : 
+                                          exportSet.transfers[0].destcurrencyid ;
+            bridgeConverterActive = (importCurrency.toLowerCase() === constants.BRIDGECURRENCYHEX[InteractorConfig.ticker].toLowerCase())
+                                   
             outputSet.height = exportSet.endHeight;
             outputSet.txid = util.removeHexLeader(exportSet.exportHash).reversebytes(); //export hash used for txid
             outputSet.txoutnum = 0; //exportSet.position;

--- a/ethInteractor.js
+++ b/ethInteractor.js
@@ -598,7 +598,6 @@ function createCrossChainExport(transfers, startHeight, endHeight, jsonready = f
     cce.rewardaddress = ""; //  blank
     cce.firstinput = 1;
     if (InteractorConfig.debugsubmit) {
-        console.log(JSON.stringify(cce.totalamounts),null,2);
         console.log("cce", JSON.stringify(cce),null,2);
     }
     return cce;
@@ -812,7 +811,8 @@ exports.getExports = async(input) => {
 
             let outputSet = {};
 
-            bridgeConverterActive = exportSet.transfers[0].destcurrencyid.toLowerCase() == constants.BRIDGECURRENCYHEX[InteractorConfig.ticker].toLowerCase();
+            bridgeConverterActive = exportSet.transfers[0].destcurrencyid.toLowerCase() === constants.BRIDGECURRENCYHEX[InteractorConfig.ticker].toLowerCase()
+                                        || exportSet.transfers[0].feecurrencyid.toLowerCase() === constants.VETHIDHEX[InteractorConfig.ticker].toLowerCase();
             outputSet.height = exportSet.endHeight;
             outputSet.txid = util.removeHexLeader(exportSet.exportHash).reversebytes(); //export hash used for txid
             outputSet.txoutnum = 0; //exportSet.position;


### PR DESCRIPTION
The logic to detect whether the bridge converter has been launched had a case in it where if you sent Bridge.vETH as a conversion to one of its reserve currencies it would wrongly detect the bridge converter as not being active.  This pull request addresses the issue by detecting whether the fee currency is vETH as these are the only two allowed states.  Either the destination currency is Bridge.vETH or if not then the fee currency must be vETH, as this is the only allowed state if the destination currency is not Bridge.vETH.